### PR TITLE
Fix: Remove mid-file import in auth routes

### DIFF
--- a/backend/app/blueprints/auth/routes.py
+++ b/backend/app/blueprints/auth/routes.py
@@ -29,12 +29,8 @@ def register(body: UserRegisterSchema):
         400: Validation error or user already exists
     """
     try:
-        # Register user
-        user = AuthService.register_user(body)
-        
-        # Generate token for immediate login
-        from app.utils.jwt_utils import generate_token
-        access_token, expires_in = generate_token(user.id)
+        # Register user and generate token for immediate login
+        user, access_token, expires_in = AuthService.register_user_with_token(body)
         
         # Create response
         user_response = UserResponseSchema.from_orm(user)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -68,6 +68,28 @@ class AuthService:
             raise ValueError("Failed to create user") from e
     
     @staticmethod
+    def register_user_with_token(user_data: UserRegisterSchema) -> tuple[User, str, int]:
+        """
+        Register a new user and generate JWT token for immediate login.
+        
+        Args:
+            user_data: Validated user registration data
+            
+        Returns:
+            Tuple of (User, access_token, expires_in)
+            
+        Raises:
+            ValueError: If username or email already exists
+        """
+        # Register the user
+        user = AuthService.register_user(user_data)
+        
+        # Generate token for immediate login
+        access_token, expires_in = generate_token(user.id)
+        
+        return user, access_token, expires_in
+    
+    @staticmethod
     def authenticate_user(login_data: UserLoginSchema) -> tuple[User, str, int]:
         """
         Authenticate a user and generate JWT token.


### PR DESCRIPTION
## Problem
The auth routes file had an import statement in the middle of a function (line 36), violating PEP 8 guidelines and making the code harder to read and maintain.

## Solution
- Analyzed for circular import dependencies - found none
- Created a new `AuthService.register_user_with_token()` method that combines user registration with token generation
- Removed the mid-file import from `routes.py`
- Improved code organization by keeping all token generation logic in the service layer

## Changes Made
1. **backend/app/blueprints/auth/routes.py**
   - Removed the mid-file import of `generate_token` from line 36
   - Updated the register endpoint to use the new service method

2. **backend/app/services/auth_service.py**
   - Added `register_user_with_token()` method that wraps `register_user()` and adds token generation
   - This maintains separation of concerns and is consistent with the existing `authenticate_user()` pattern

## Testing
✅ All 16 authentication tests pass successfully
- Ran tests locally with `python tests/run_tests.py --local --verbose`
- No functionality was broken by this refactoring

## Benefits
- ✅ PEP 8 compliant import structure
- ✅ Better code organization and readability
- ✅ Consistent service layer patterns
- ✅ All business logic consolidated in the service layer