### PR TITLE
Remove cloud test database support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,12 +23,3 @@ TEST_DATABASE_URL=postgresql://your_user:your_password@localhost:5456/your_test_
 
 # Local test database (Docker)
 TEST_DATABASE_URL_LOCAL=postgresql://your_user:your_password@localhost:5456/your_test_database_name
-
-# Cloud test database (AWS Aurora Serverless)
-TEST_DATABASE_URL_CLOUD=postgresql://username:password@your-aurora-cluster.region.rds.amazonaws.com:5432/test_database_name
-
-# Test database target (local or cloud) - defaults to 'local' if not set
-TEST_DB_TARGET=local
-
-# Optional: Set to true if cloud database requires VPN
-CLOUD_DB_REQUIRES_VPN=false

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -2,12 +2,12 @@
 
 ## Overview
 This directory contains all unit and integration tests for the Meal Planner API.
-Tests can be run against either a local Docker PostgreSQL database or a cloud AWS Aurora database.
+Tests are run against a local Docker PostgreSQL database.
 
 ## Test Structure
 - `conftest.py` - Pytest fixtures and test configuration
-- `db_config.py` - Database configuration for local and cloud testing
-- `run_tests.py` - Convenient test runner script for database selection
+- `db_config.py` - Database configuration for local testing
+- `run_tests.py` - Convenient test runner script
 - `test_auth.py` - Authentication endpoint tests
 
 ## Database Configuration
@@ -19,26 +19,21 @@ All database URLs are configured in the `.env` file in the project root.
 - `DEV_DATABASE_URL` - Development database connection (port 5455)
 - Used when running the Flask app locally with `flask run`
 
-#### Test Databases
+#### Test Database
 - `TEST_DATABASE_URL_LOCAL` - Local Docker test database (port 5456)
-- `TEST_DATABASE_URL_CLOUD` - AWS Aurora cloud test database
 - `TEST_DATABASE_URL` - Active test database (automatically set by test runner)
 
-#### Database Selection
-- `TEST_DB_TARGET` - Default target: `local` or `cloud` (defaults to `local`)
-
-**Note:** The test runner script (`run_tests.py`) automatically sets `TEST_DATABASE_URL` based on your target selection.
+**Note:** The test runner script (`run_tests.py`) automatically sets `TEST_DATABASE_URL` to use the local test database.
 
 ## Using the Test Runner Script
 
-The `run_tests.py` script provides a convenient way to run tests with different databases:
+The `run_tests.py` script provides a convenient way to run tests:
 
 ```bash
 # From the backend directory
-python tests/run_tests.py                    # Run with local database (default)
-python tests/run_tests.py --cloud            # Run with cloud database
-python tests/run_tests.py --check            # Check database connections
-python tests/run_tests.py --cloud --verbose  # Cloud database with verbose output
+python tests/run_tests.py                    # Run all tests
+python tests/run_tests.py --check            # Check database connection
+python tests/run_tests.py --verbose          # Run with verbose output
 python tests/run_tests.py --coverage         # Run with coverage report
 python tests/run_tests.py --file tests/test_auth.py  # Run specific test file
 ```
@@ -57,51 +52,21 @@ python tests/run_tests.py --file tests/test_auth.py  # Run specific test file
    docker-compose -f docker-compose.test.yml up -d
    ```
 
-### Run Tests with Local Database
+### Run Tests
 ```bash
 # Using the test runner script (recommended)
-python tests/run_tests.py --local
+python tests/run_tests.py
 
 # Or directly with pytest (requires TEST_DATABASE_URL to be set)
 pytest
 
 # With verbose output
-python tests/run_tests.py --local --verbose
+python tests/run_tests.py --verbose
 
 # With coverage report
-python tests/run_tests.py --local --coverage
+python tests/run_tests.py --coverage
 ```
 
-## Running Tests with Cloud Database
-
-### Prerequisites
-1. Ensure cloud database credentials are in your `.env` file
-2. Ensure you can connect to the AWS Aurora database
-   ```bash
-   # Test connection (optional)
-   psql -h meal-planner-db.cluster-cczg0cscuj55.us-east-1.rds.amazonaws.com -U postgres_admin -d meal_planner_test
-   ```
-
-### Run Tests with Cloud Database
-```bash
-# Using the test runner script (recommended)
-python tests/run_tests.py --cloud
-
-# With verbose output
-python tests/run_tests.py --cloud --verbose
-
-# Run specific test file with cloud database
-python tests/run_tests.py --cloud --file tests/test_auth.py
-
-# With coverage report
-python tests/run_tests.py --cloud --coverage
-```
-
-### ⚠️ Cloud Database Notes
-- The cloud database will be completely dropped and recreated for each test
-- Make sure this is a dedicated test database, not production
-- Tests may run slower due to network latency
-- Ensure stable internet connection for consistent test results
 
 ### Run Specific Test Files
 ```bash
@@ -132,7 +97,7 @@ pytest --cov=app --cov-report=html
 # Open htmlcov/index.html in browser
 ```
 
-## Test Databases
+## Test Database
 
 ### Local Test Database (Docker)
 - **Port**: 5456 (different from development port 5455)
@@ -140,12 +105,7 @@ pytest --cov=app --cov-report=html
 - **Database**: `meal_planner_test_db`
 - **Docker Compose**: `docker-compose.test.yml`
 
-### Cloud Test Database (AWS Aurora)
-- **Type**: AWS Aurora Serverless PostgreSQL
-- **Database**: `meal_planner_test`
-- **Region**: us-east-1
-
-**Note**: Both databases are automatically cleared and recreated for each test function to ensure test isolation.
+**Note**: The database is automatically cleared and recreated for each test function to ensure test isolation.
 
 ## Writing New Tests
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,16 +1,15 @@
 """
-Pytest fixtures for test setup using PostgreSQL test database.
+Pytest fixtures for test setup using local Docker PostgreSQL test database.
 
-The TEST_DATABASE_URL environment variable determines which database to use.
-This is set by the run_tests.py script based on --local or --cloud flags.
+The TEST_DATABASE_URL environment variable is automatically set by the run_tests.py script
+to use the local Docker test database.
 
 Direct pytest usage:
-- Set TEST_DATABASE_URL env var to desired database URL
+- Ensure TEST_DATABASE_URL env var is set to TEST_DATABASE_URL_LOCAL
 - Run: pytest
 
-Using run_tests.py:
-- Local: python run_tests.py --local
-- Cloud: python run_tests.py --cloud
+Using run_tests.py (recommended):
+- python run_tests.py
 """
 
 import pytest
@@ -23,7 +22,7 @@ def app():
     Create a Flask app configured for testing with PostgreSQL.
     
     Uses TEST_DATABASE_URL environment variable which should be set
-    by the run_tests.py script based on --local or --cloud flag.
+    by the run_tests.py script to point to the local Docker test database.
     
     scope='function' means this runs for each test function
     """
@@ -32,7 +31,7 @@ def app():
     from app.models.entities import User
     
     # Create app with test config
-    # The TestingConfig will use TEST_DATABASE_URL which was set by pytest_plugins.py
+    # The TestingConfig will use TEST_DATABASE_URL which was set by run_tests.py
     app = create_app('testing')
     
     # Create tables in test database


### PR DESCRIPTION
## Description
This PR removes all cloud test database support from the project, simplifying the testing infrastructure to use only the local Docker PostgreSQL database.

## Changes Made

### 🗑️ Removed Cloud Database Support
- Removed AWS Aurora cloud database testing infrastructure
- Simplified test configuration to only use local Docker PostgreSQL
- Removed all cloud-related configuration and documentation

### 📝 Updated Files
- ****: Removed cloud-related methods and simplified to local-only testing
- ****: Removed --cloud flag and all cloud-related logic
- ****: Updated documentation to reflect local-only testing
- ****: Removed all cloud database sections and references
- ****: Removed TEST_DATABASE_URL_CLOUD and related variables

## Motivation
- Simplifies the test setup and reduces complexity
- Removes unnecessary cloud dependencies for local development
- Prepares for moving the serverless application to a separate repository

## Testing
✅ All 16 authentication tests pass with the local Docker database

## Test Command
```bash
# Activate environment
conda activate meal-planner

# Start test database
docker-compose -f docker-compose.test.yml up -d

# Run tests
cd backend && python tests/run_tests.py
```

## Breaking Changes
⚠️ This removes the ability to run tests against AWS Aurora cloud database. Users who were using  flag will need to use the local Docker database instead.

## Next Steps
- Create a separate repository for the serverless application
- Address Pydantic v2 migration warnings (separate task)